### PR TITLE
fix: pass crates.io token via --token flag to fix empty token error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Publish grain-id to crates.io
-        run: cargo publish -p grain-id
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p grain-id --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Publish grain-id-cli to crates.io
-        run: cargo publish -p grain-id-cli
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p grain-id-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Fix "please provide non-empty token" error when publishing to crates.io
- Pass `CARGO_REGISTRY_TOKEN` via `--token` flag instead of env var for explicit token handling

## Test plan

- [ ] Verify the next release triggers the `publish` job without the empty token error

🤖 Generated with [Claude Code](https://claude.com/claude-code)