### PR TITLE
Group Cargo patch updates and schedule on Fridays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
     exclude-paths:
       - "fuzz"
+    groups:
+      cargo-patch:
+        update-types:
+          - "patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"


### PR DESCRIPTION
## Summary

- Add a `cargo-patch` group to consolidate Cargo patch version updates into a single PR
- Schedule both Cargo and GitHub Actions dependabot runs on Fridays (UTC 05:00 = JST 14:00)

## Motivation

Patch versions are API-stable by semver contract, so batching them reduces noise without sacrificing review granularity where it matters. Friday scheduling allows weekend releases with sufficient lead time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)