### PR TITLE
release: v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.14.2 - 2026-04-12
+
+### Changed
+
+- Bump `redb` from 3.1.0 to 4.0.0
+- Bump `jsonschema` (dev) from 0.45 to 0.46
+- Bump `actions/checkout` from v4 to v6
+- Bump `actions/upload-artifact` from v4 to v7
+- Bump `actions/download-artifact` from v4 to v8
+
+### Added
+
+- Add `publish` job to release workflow for automatic publishing to crates.io
+- Add Dependabot configuration for GitHub Actions
+- Add workflow to auto-merge Dependabot patch updates
+- Group Cargo patch dependency updates in Dependabot
+
 ## 0.14.1 - 2026-04-03
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ arbitrary = { version = "1", optional = true }
 digest = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 rand = { workspace = true, default-features = false, optional = true }
-redb = { version = "3.1.0", optional = true }
+redb = { version = "4.0.0", optional = true }
 rusqlite = { version = "0.39.0", default-features = false, optional = true }
 schemars = { version = "1.2.1", default-features = false, optional = true }
 sea-orm = { version = "1.1.16", default-features = false, optional = true }
@@ -52,7 +52,7 @@ rand = { workspace = true, default-features = false, features = ["thread_rng"]}
 sha1.workspace = true
 sha2.workspace = true
 sha3.workspace = true
-jsonschema = "0.45"
+jsonschema = "0.46"
 serde_json = "1.0"
 
 [workspace]
@@ -64,7 +64,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/grain-id"
 homepage = "https://github.com/fluo10/grain-id"
 keywords = ["id", "identifier", "uuid", "distributed", "human-readable"]
-version = "0.14.1"
+version = "0.14.2"
 
 [workspace.dependencies]
 chrono = "0.4.42"


### PR DESCRIPTION
## Summary

- Bump `redb` from 3.1.0 to 4.0.0
- Bump `jsonschema` (dev) from 0.45 to 0.46
- Bump `actions/checkout` from v4 to v6
- Bump `actions/upload-artifact` from v4 to v7
- Bump `actions/download-artifact` from v4 to v8
- Add `publish` job to release workflow for automatic publishing to crates.io
- Add Dependabot configuration for GitHub Actions and auto-merge workflow for patch updates

## Test plan

- [x] All tests pass with `cargo test --all-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)