### PR TITLE
feat: add public GrainId::from_byte_prefix method

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -522,6 +522,34 @@ impl GrainId {
         GrainId::from_u64_lossy(self.to_u64().wrapping_sub(rhs.to_u64()))
     }
 
+    /// Creates a `GrainId` from the leading (most significant) 35 bits of a 5-byte array.
+    ///
+    /// This is useful for generating a compact identifier from a pre-computed hash,
+    /// public key, or any arbitrary byte sequence.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use grain_id::*;
+    /// // Extract leading 35 bits from a byte array
+    /// let bytes = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+    /// let id = GrainId::from_byte_prefix(&bytes);
+    /// assert_eq!(id, GrainId::MAX);
+    ///
+    /// // For longer data, slice the first 5 bytes
+    /// let hash: [u8; 32] = [0; 32];
+    /// let id = GrainId::from_byte_prefix(hash[..5].try_into().unwrap());
+    /// assert_eq!(id, GrainId::NIL);
+    /// ```
+    pub const fn from_byte_prefix(bytes: &[u8; 5]) -> Self {
+        let value = (bytes[0] as u64) << 27
+            | (bytes[1] as u64) << 19
+            | (bytes[2] as u64) << 11
+            | (bytes[3] as u64) << 3
+            | (bytes[4] as u64) >> 5;
+        Self::from_u64_lossy(value)
+    }
+
     /// Increments the value by 1, wrapping around to [`GrainId::NIL`] on overflow.
     ///
     /// # Examples

--- a/src/digest.rs
+++ b/src/digest.rs
@@ -1,15 +1,5 @@
 use super::*;
 
-fn extract_35_bits(bytes: &[u8]) -> GrainId {
-    debug_assert!(bytes.len() >= 5);
-    let value = (bytes[0] as u64) << 27
-        | (bytes[1] as u64) << 19
-        | (bytes[2] as u64) << 11
-        | (bytes[3] as u64) << 3
-        | (bytes[4] as u64) >> 5;
-    GrainId::from_u64_lossy(value)
-}
-
 impl GrainId {
     /// Generate a [`GrainId`] from arbitrary bytes using a fixed-output hash function.
     ///
@@ -40,7 +30,7 @@ impl GrainId {
             "digest output is {} bytes, but at least 5 bytes are required",
             output.len()
         );
-        extract_35_bits(&output)
+        Self::from_byte_prefix(output[..5].try_into().unwrap())
     }
 
     /// Generate a [`GrainId`] from arbitrary bytes using an extendable-output function (XOF).
@@ -70,6 +60,6 @@ impl GrainId {
         let mut reader = hasher.finalize_xof();
         let mut buf = [0u8; 5];
         reader.read(&mut buf);
-        extract_35_bits(&buf)
+        Self::from_byte_prefix(&buf)
     }
 }


### PR DESCRIPTION
## Summary
- Add `GrainId::from_byte_prefix(&[u8; 5]) -> Self` as a public `const fn` that extracts the leading 35 bits from a 5-byte array
- Enables generating compact identifiers from pre-computed hashes, public keys, or other arbitrary byte data without the `digest` feature
- Replace private `extract_35_bits` in `digest.rs` with the new public method

## Test plan
- [x] All existing tests pass (36 passed, 0 failed)
- [x] Doctest examples verify `GrainId::MAX` from `[0xFF; 5]` and `GrainId::NIL` from `[0x00; 32]`
- [x] `from_digest` and `from_xof` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)