### PR TITLE
ci: run publish job in parallel with build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
           files: artifacts/*
 
   publish:
-    needs: [prepare, release]
+    needs: prepare
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Remove the `release` dependency from the `publish` job so it no longer waits for binary artifacts to be built and uploaded
- `publish` now depends only on `prepare`, letting it run concurrently with `build`
- Pipeline shape changes from serial (`prepare → build → release → publish`) to parallel (`prepare → build → release` / `prepare → publish`)

## Test plan

- [ ] Trigger a release PR merge and confirm `publish` and `build` start at the same time in the Actions run
- [ ] Confirm crates.io publish succeeds independently of the binary release step

🤖 Generated with [Claude Code](https://claude.com/claude-code)