### PR TITLE
chore: bump version to v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.15.0 - 2026-04-14
+
+### Added
+
+- `GrainId::from_byte_prefix` public method for constructing an ID from a byte prefix
+- Byte prefix/suffix API for range-based queries
+
+### Changed
+
+- Deprecate legacy bytes methods in favor of new prefix/suffix API
+
+### Removed
+
+- `redb` feature and its integration
+
 ## 0.14.2 - 2026-04-12
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/fluo10/grain-id"
 homepage = "https://github.com/fluo10/grain-id"
 keywords = ["id", "identifier", "uuid", "distributed", "human-readable"]
-version = "0.14.2"
+version = "0.15.0"
 
 [workspace.dependencies]
 chrono = "0.4.42"

--- a/examples/grain-id-cli/Cargo.toml
+++ b/examples/grain-id-cli/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/main.rs"
 anyhow = "1.0.100"
 chrono.workspace = true
 clap = { version = "4.5.48", features = ["derive"] }
-grain-id = { path = "../..", version = "0.14.1", features = ["digest"] }
+grain-id = { path = "../..", version = "0.15.0", features = ["digest"] }
 md-5.workspace = true
 rand.workspace = true
 sha1.workspace = true
@@ -26,7 +26,7 @@ sha2.workspace = true
 
 [dev-dependencies]
 digest.workspace = true
-grain-id = { path = "../..", version = "0.14.1", features = ["digest"] }
+grain-id = { path = "../..", version = "0.15.0", features = ["digest"] }
 md-5.workspace = true
 sha1.workspace = true
 sha2.workspace = true

--- a/src/core.rs
+++ b/src/core.rs
@@ -450,7 +450,9 @@ impl GrainId {
     /// # }
     /// ```
     pub fn from_be_bytes_compact(bytes: [u8; 5]) -> Result<Self, Error> {
-        Self::from_u64(u64::from_be_bytes([0, 0, 0, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4]]))
+        Self::from_u64(u64::from_be_bytes([
+            0, 0, 0, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4],
+        ]))
     }
 
     #[deprecated(
@@ -477,7 +479,9 @@ impl GrainId {
     /// # }
     /// ```
     pub fn from_le_bytes_compact(bytes: [u8; 5]) -> Result<Self, Error> {
-        Self::from_u64(u64::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], 0, 0, 0]))
+        Self::from_u64(u64::from_le_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], 0, 0, 0,
+        ]))
     }
 
     #[deprecated(since = "0.15.0", note = "Use `from_byte_suffix()` instead.")]
@@ -504,7 +508,9 @@ impl GrainId {
     /// # }
     /// ```
     pub fn from_be_bytes_compact_lossy(bytes: [u8; 5]) -> Self {
-        Self::from_u64_lossy(u64::from_be_bytes([0, 0, 0, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4]]))
+        Self::from_u64_lossy(u64::from_be_bytes([
+            0, 0, 0, bytes[0], bytes[1], bytes[2], bytes[3], bytes[4],
+        ]))
     }
 
     #[deprecated(
@@ -534,7 +540,9 @@ impl GrainId {
     /// # }
     /// ```
     pub fn from_le_bytes_compact_lossy(bytes: [u8; 5]) -> Self {
-        Self::from_u64_lossy(u64::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], 0, 0, 0]))
+        Self::from_u64_lossy(u64::from_le_bytes([
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], 0, 0, 0,
+        ]))
     }
 
     /// Wrapping (modular) subtraction. Computes `self - rhs`, wrapping around at the boundary of the type.


### PR DESCRIPTION
## Summary

- Bump workspace version to `0.15.0`
- Update `grain-id` dependency in `grain-id-cli` to `0.15.0`
- Add `0.15.0` entry to `CHANGELOG.md`
- Apply `cargo fmt` formatting fixes in `src/core.rs`

## Changes included in this release

- **Removed**: `redb` feature and its integration
- **Added**: `GrainId::from_byte_prefix` method and byte prefix/suffix API
- **Deprecated**: legacy bytes methods in favor of new prefix/suffix API

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)