### PR TITLE
chore(release): introduce release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,55 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+# release コマンドと release-pr が同じブランチで競合しないように
+# 1 つの release-plz workflow が走っている間は次回起動を待たせる。
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,40 +1,15 @@
-name: Release
+name: Release binaries
 
+# release-plz が GitHub release を作成した時にバイナリビルドを起動する。
+# crates.io publish と tag/release 作成は release-plz.yml が担当。
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
+  release:
+    types: [published]
 
 jobs:
-  prepare:
-    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'release/')
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-
-      - name: Extract version from branch name
-        id: version
-        run: |
-          BRANCH="${{ github.event.pull_request.head.ref }}"
-          VERSION="${BRANCH#release/}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-      - name: Create tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag ${{ steps.version.outputs.version }}
-          git push origin ${{ steps.version.outputs.version }}
-
   build:
-    needs: prepare
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
@@ -50,12 +25,17 @@ jobs:
             binary: grain-id
             asset_name: grain-id-linux-aarch64
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.event.release.tag_name }}
+          submodules: true
+
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+
       - run: cargo build --release -p grain-id-cli
 
       - name: Rename binary (Unix)
@@ -67,38 +47,8 @@ jobs:
         shell: pwsh
         run: Copy-Item target/release/${{ matrix.binary }} ${{ matrix.asset_name }}
 
-      - uses: actions/upload-artifact@v7
-        with:
-          name: ${{ matrix.asset_name }}
-          path: ${{ matrix.asset_name }}
-
-  release:
-    needs: [prepare, build]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          path: artifacts
-          merge-multiple: true
-
-      - uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.prepare.outputs.version }}
-          generate_release_notes: true
-          files: artifacts/*
-
-  publish:
-    needs: prepare
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - name: Publish grain-id to crates.io
-        run: cargo publish -p grain-id --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      - name: Publish grain-id-cli to crates.io
-        run: cargo publish -p grain-id-cli --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Upload binary to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: gh release upload "${{ github.event.release.tag_name }}" "${{ matrix.asset_name }}" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,6 @@ All notable changes to this workspace will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
 ## 0.15.0 - 2026-04-14
 
 ### Added

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,44 @@
+[workspace]
+# 公開クレートは統一バージョン（workspace.package.version）で運用する。
+# 既存タグ運用に合わせて、ワークスペース全体で 1 つの `v{version}` タグと
+# GitHub release だけを作る。crates.io publish は各クレート個別に行う。
+changelog_update = true
+dependencies_update = true
+publish = true
+release = true
+git_release_enable = false
+git_tag_enable = false
+pr_branch_prefix = "release-plz/"
+pr_labels = ["release"]
+
+# メイン crate がタグと GitHub release を担当する。
+[[package]]
+name = "grain-id"
+git_tag_enable = true
+git_release_enable = true
+git_tag_name = "v{{ version }}"
+git_release_name = "v{{ version }}"
+version_group = "workspace"
+
+[[package]]
+name = "grain-id-cli"
+version_group = "workspace"
+
+# Cargo.toml 側で publish = false の crate は release-plz 側にも明示する
+# （per-package の publish 設定は Cargo.toml と一致している必要がある）。
+[[package]]
+name = "grain-id-prost-example"
+release = false
+publish = false
+
+[changelog]
+# 既存 CHANGELOG.md のヘッダーをそのまま維持し、新規エントリは
+# このヘッダーの下に挿入される（既存履歴は保持される）。
+header = """# Changelog
+
+All notable changes to this workspace will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""


### PR DESCRIPTION
## Summary
- `release-plz.toml` を新規追加。`grain-id` と `grain-id-cli` を `version_group = \"workspace\"` で統一バージョン管理し、`grain-id` が `v{version}` 単一タグと GitHub release を担当。`grain-id-prost-example` は `publish = false` で対象外（`fuzz/` は別 workspace なので元から無関係）。
- `.github/workflows/release-plz.yml` を新規追加。`push: main` で release PR の作成と、merge 後の crates.io publish / tag / GH release 作成を行う。
- `.github/workflows/release.yml` を `release: published` トリガーに改修。バイナリビルド＋ `gh release upload` のみに縮小し、`cargo publish` と tag 作成は release-plz に移譲。
- `CHANGELOG.md` の `## Unreleased` セクションを削除。残したままだと release-plz が新しいエントリを `## Unreleased` の上に挿入し、孤立したセクションが残ってしまうため。

## 動作の流れ（マージ後）
1. main への push を契機に release-plz が動き、pending な変更から release PR を自動作成。
2. PR の中身（CHANGELOG / `Cargo.toml` のバージョン）を確認してマージ。
3. release-plz が `v{version}` タグと GH release を作り、`grain-id` → `grain-id-cli` の順に crates.io へ publish。
4. GH release が published になると `release.yml` が起動し、各プラットフォーム向け CLI バイナリを release にアップロード。

## 前提
- リポジトリ secret に `RELEASE_PLZ_TOKEN` （fine-grained PAT、Contents + Pull requests の read/write）が登録されていること
- `CARGO_REGISTRY_TOKEN` は既存のものを継続利用
- release-plz workflow / binary build workflow ともに `submodules: true` を指定（grain-id-proto submodule への依存）

## 既知の差分
- 新しい CHANGELOG エントリは release-plz/git-cliff の標準フォーマット (`## [X.Y.Z] - YYYY-MM-DD` ブラケット付き) になる予定。既存の `## X.Y.Z - YYYY-MM-DD` 形式とは少し見た目が変わる可能性がある（必要なら `[changelog]` の body テンプレートで合わせ込み可能）。

## Test plan
- [ ] PR マージ後、Release-plz workflow が成功し release PR が出ること
- [ ] release PR の差分（CHANGELOG, Cargo.toml, Cargo.lock）が想定通りであること
- [ ] release PR マージ後に `v{version}` タグ・GH release・crates.io publish が完了すること
- [ ] release.yml が GH release の published を受けてバイナリをアップロードすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)