### PR TITLE
ci: add cargo-deny for license and advisory checks

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,27 @@
+name: cargo-deny
+
+# License compatibility, advisory (RUSTSEC) scanning, banned crates, and
+# unknown-source checks. The weekly schedule catches newly-filed advisories
+# against deps that haven't changed.
+
+on:
+  pull_request:
+    paths:
+      - "**/Cargo.toml"
+      - "Cargo.lock"
+      - "deny.toml"
+      - ".github/workflows/cargo-deny.yml"
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,42 @@
+# cargo-deny config. Run locally with `cargo deny check`.
+# Reference: https://embarkstudios.github.io/cargo-deny/
+
+[graph]
+# Restrict the dep graph to the platforms CI exercises (see ci.yml). This
+# drops UEFI-only transitive deps like `r-efi` (LGPL-2.1-or-later) pulled in
+# by `getrandom`, so we don't need to globally allow their licenses.
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc",
+]
+all-features = true
+
+[advisories]
+yanked = "warn"
+
+[licenses]
+# Permissive SPDX identifiers actually present in the resolved graph.
+# Re-survey with `cargo deny list --layout license` before widening.
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+confidence-threshold = 0.93
+
+[bans]
+# Duplicate-version warnings are too noisy in real Rust workspaces (every
+# transitively-pulled `syn`/`bitflags`/`hashbrown` version trips it).
+multiple-versions = "allow"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

Adds [cargo-deny](https://embarkstudios.github.io/cargo-deny/) to gate PRs and main on license compatibility, RUSTSEC advisories, banned crates, and unknown sources. Closes #121.

### `deny.toml` highlights

- **Target filtering** — `[graph] targets` restricts analysis to the four platforms CI exercises (Linux x86_64/aarch64, macOS aarch64, Windows x86_64). Drops UEFI-only transitive deps like `r-efi` (LGPL-2.1-or-later) pulled in by `getrandom`, so we don't need to globally allow that license.
- **License allowlist** — explicit enumeration of the permissive SPDX IDs actually present in the resolved graph (surveyed via `cargo deny list --layout license` with `--all-features`). Widening requires re-surveying, keeping the allowlist a conscious decision rather than drift.
- **No per-crate exceptions** — unlike sister repo's config, this repo has no GPL or font carve-outs.
- **No ignored advisories** — local `cargo deny check` came up clean once `cargo update -p rand -p rustls-webpki` was run (which CI will do at lockfile generation since `Cargo.lock` is gitignored for this library crate).
- **`multiple-versions = "allow"`** — duplicate-version noise is unavoidable in real Rust workspaces; CVEs are what we actually care about here.

### Workflow

Runs on PR (when Cargo metadata, `deny.toml`, or the workflow itself change), on push to main, on a weekly schedule (Mon 06:00 UTC), and via `workflow_dispatch`.

### Verified locally

```
$ cargo deny check
advisories ok, bans ok, licenses ok, sources ok
```

## Test plan

- [ ] CI `cargo-deny` job passes on this PR
- [ ] Confirm the scheduled run fires on Monday 06:00 UTC after merge
- [ ] If a future PR adds a dep with a new SPDX identifier, confirm the check fails with a useful diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)